### PR TITLE
Some fix upon Parser module (Parser & ParseTree & CharType) 

### DIFF
--- a/build/msvc2017/chtholly/chtholly.sln.DotSettings
+++ b/build/msvc2017/chtholly/chtholly.sln.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Chtholly/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=opcode/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=oprands/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/build/msvc2017/chtholly/chtholly.vcxproj
+++ b/build/msvc2017/chtholly/chtholly.vcxproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ClInclude Include="..\..\..\src\chtholly.hpp" />
     <ClInclude Include="..\..\..\src\chtholly\chartype.hpp" />
+    <ClInclude Include="..\..\..\src\chtholly\irgenerator.hpp" />
     <ClInclude Include="..\..\..\src\chtholly\parser.hpp" />
     <ClInclude Include="..\..\..\src\chtholly\parserc.hpp" />
     <ClInclude Include="..\..\..\src\chtholly\parsetree.hpp" />

--- a/build/msvc2017/chtholly/chtholly.vcxproj.filters
+++ b/build/msvc2017/chtholly/chtholly.vcxproj.filters
@@ -25,5 +25,8 @@
     <ClInclude Include="..\..\..\src\chtholly.hpp">
       <Filter>ALL</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\src\chtholly\irgenerator.hpp">
+      <Filter>SRC</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/chtholly/chartype.hpp
+++ b/src/chtholly/chartype.hpp
@@ -29,20 +29,18 @@ namespace Chtholly
 	{
 		CharType() = delete;
 
-		using Type = int(*)(int);
-
-		inline static Type isAlphaOrNum		= std::isalnum;
-		inline static Type isAlpha			= std::isalpha;
-		inline static Type isLowercaseAlpha	= std::islower;
-		inline static Type isUppercaseAlpha	= std::isupper;
-		inline static Type isDigit			= std::isdigit;
-		inline static Type isHexDigit		= std::isxdigit;
-		inline static Type isControl		= std::iscntrl;
-		inline static Type isGraphic		= std::isgraph;
-		inline static Type isSpace			= std::isspace;
-		inline static Type isBlank			= std::isblank;
-		inline static Type isPrintable		= std::isprint;
-		inline static Type isPunctuation	= std::ispunct;
+		inline static auto isAlphaOrNum		= std::isalnum;
+		inline static auto isAlpha			= std::isalpha;
+		inline static auto isLowercaseAlpha	= std::islower;
+		inline static auto isUppercaseAlpha	= std::isupper;
+		inline static auto isDigit			= std::isdigit;
+		inline static auto isHexDigit		= std::isxdigit;
+		inline static auto isControl		= std::iscntrl;
+		inline static auto isGraphic		= std::isgraph;
+		inline static auto isSpace			= std::isspace;
+		inline static auto isBlank			= std::isblank;
+		inline static auto isPrintable		= std::isprint;
+		inline static auto isPunctuation	= std::ispunct;
 	};
 
 	template <>
@@ -50,19 +48,17 @@ namespace Chtholly
 	{
 		CharType() = delete;
 
-		using Type = int(*)(std::wint_t);
-
-		inline static Type isAlphaOrNum		= std::iswalnum;
-		inline static Type isAlpha			= std::iswalpha;
-		inline static Type isLowercaseAlpha = std::iswlower;
-		inline static Type isUppercaseAlpha = std::iswupper;
-		inline static Type isDigit			= std::iswdigit;
-		inline static Type isHexDigit		= std::iswxdigit;
-		inline static Type isControl		= std::iswcntrl;
-		inline static Type isGraphic		= std::iswgraph;
-		inline static Type isSpace			= std::iswspace;
-		inline static Type isBlank			= std::iswblank;
-		inline static Type isPrintable		= std::iswprint;
-		inline static Type isPunctuation	= std::iswpunct;
+		inline static auto isAlphaOrNum		= std::iswalnum;
+		inline static auto isAlpha			= std::iswalpha;
+		inline static auto isLowercaseAlpha = std::iswlower;
+		inline static auto isUppercaseAlpha = std::iswupper;
+		inline static auto isDigit			= std::iswdigit;
+		inline static auto isHexDigit		= std::iswxdigit;
+		inline static auto isControl		= std::iswcntrl;
+		inline static auto isGraphic		= std::iswgraph;
+		inline static auto isSpace			= std::iswspace;
+		inline static auto isBlank			= std::iswblank;
+		inline static auto isPrintable		= std::iswprint;
+		inline static auto isPunctuation	= std::iswpunct;
 	};
 }

--- a/src/chtholly/chartype.hpp
+++ b/src/chtholly/chartype.hpp
@@ -29,18 +29,20 @@ namespace Chtholly
 	{
 		CharType() = delete;
 
-		inline static auto isAlphaOrNum		= std::isalnum;
-		inline static auto isAlpha			= std::isalpha;
-		inline static auto isLowercaseAlpha	= std::islower;
-		inline static auto isUppercaseAlpha	= std::isupper;
-		inline static auto isDigit			= std::isdigit;
-		inline static auto isHexDigit		= std::isxdigit;
-		inline static auto isControl		= std::iscntrl;
-		inline static auto isGraphic		= std::isgraph;
-		inline static auto isSpace			= std::isspace;
-		inline static auto isBlank			= std::isblank;
-		inline static auto isPrintable		= std::isprint;
-		inline static auto isPunctuation	= std::ispunct;
+		using Type = int(*)(int);
+
+		inline static auto isAlphaOrNum		= static_cast<Type>(std::isalnum);
+		inline static auto isAlpha			= static_cast<Type>(std::isalpha);
+		inline static auto isLowercaseAlpha	= static_cast<Type>(std::islower);
+		inline static auto isUppercaseAlpha	= static_cast<Type>(std::isupper);
+		inline static auto isDigit			= static_cast<Type>(std::isdigit);
+		inline static auto isHexDigit		= static_cast<Type>(std::isxdigit);
+		inline static auto isControl		= static_cast<Type>(std::iscntrl);
+		inline static auto isGraphic		= static_cast<Type>(std::isgraph);
+		inline static auto isSpace			= static_cast<Type>(std::isspace);
+		inline static auto isBlank			= static_cast<Type>(std::isblank);
+		inline static auto isPrintable		= static_cast<Type>(std::isprint);
+		inline static auto isPunctuation	= static_cast<Type>(std::ispunct);
 	};
 
 	template <>
@@ -48,17 +50,19 @@ namespace Chtholly
 	{
 		CharType() = delete;
 
-		inline static auto isAlphaOrNum		= std::iswalnum;
-		inline static auto isAlpha			= std::iswalpha;
-		inline static auto isLowercaseAlpha = std::iswlower;
-		inline static auto isUppercaseAlpha = std::iswupper;
-		inline static auto isDigit			= std::iswdigit;
-		inline static auto isHexDigit		= std::iswxdigit;
-		inline static auto isControl		= std::iswcntrl;
-		inline static auto isGraphic		= std::iswgraph;
-		inline static auto isSpace			= std::iswspace;
-		inline static auto isBlank			= std::iswblank;
-		inline static auto isPrintable		= std::iswprint;
-		inline static auto isPunctuation	= std::iswpunct;
+		using Type = int(*)(std::wint_t);
+
+		inline static auto isAlphaOrNum		= static_cast<Type>(std::iswalnum);
+		inline static auto isAlpha			= static_cast<Type>(std::iswalpha);
+		inline static auto isLowercaseAlpha = static_cast<Type>(std::iswlower);
+		inline static auto isUppercaseAlpha = static_cast<Type>(std::iswupper);
+		inline static auto isDigit			= static_cast<Type>(std::iswdigit);
+		inline static auto isHexDigit		= static_cast<Type>(std::iswxdigit);
+		inline static auto isControl		= static_cast<Type>(std::iswcntrl);
+		inline static auto isGraphic		= static_cast<Type>(std::iswgraph);
+		inline static auto isSpace			= static_cast<Type>(std::iswspace);
+		inline static auto isBlank			= static_cast<Type>(std::iswblank);
+		inline static auto isPrintable		= static_cast<Type>(std::iswprint);
+		inline static auto isPunctuation	= static_cast<Type>(std::iswpunct);
 	};
 }

--- a/src/chtholly/irgenerator.hpp
+++ b/src/chtholly/irgenerator.hpp
@@ -19,50 +19,45 @@ namespace Chtholly
 			Drop,
 			End
 		};
-		enum class Lambda : unsigned
+		enum class Function : unsigned
 		{
-			Begin = 0x20,
-			End
+			Start = 0x20,
+			Call
 		};
 		enum class List : unsigned
 		{
 			Push = 0x30,
-			Call
+			Pop
 		};
 		enum class Control : unsigned
 		{
-			Jump = 0x40,
-			JumpIf,
-			Mark
+			Jump = 0x40,			// 1
+			JumpIf,					// 2
+			Mark					// 1
 		};
 		enum class Object : unsigned
 		{
-			Var = 0x50,
-			VarWithInit,
-			VarWithConstraint,
-			VarWithInitAndConstraint,
-			Const,
-			ConstWithInit,
-			ConstWithConstraint,
-			ConstWithInitAndConstraint,
-			Use
+			Var = 0x50,				// 1
+			VarWithConstraint,		// 1
+			VarPack,				// 1
+			VarPackWithConstraint,	// 1
+			Const,					// 1
+			ConstWithConstraint,	// 1
+			ConstPack,				// 1
+			ConstPackWithConstraint,// 1
+			Use,					// 1
+			Init
 		};
 		enum class Pattern : unsigned
 		{
-			Var = 0x60,
-			VarWithConstraint,
-			Vars,
-			VarsWithConstraint,
-			Const,
-			ConstWithConstraint,
-			Consts,
-			ConstsWithConstraint
+			Begin = 0x60,
+			End
 		};
 		enum class Literal : unsigned
 		{
-			Int = 0x70,
-			Float,
-			String,
+			Int = 0x70,				// 1
+			Float,					// 1
+			String,					// 1
 			Null,
 			Undef,
 			True,
@@ -72,12 +67,33 @@ namespace Chtholly
 		Opcode() : value(None) {}
 
 		Opcode(Block inValue) : value(static_cast<unsigned>(inValue)) {}
-		Opcode(Lambda inValue) : value(static_cast<unsigned>(inValue)) {}
+		Opcode(Function inValue) : value(static_cast<unsigned>(inValue)) {}
 		Opcode(List inValue) : value(static_cast<unsigned>(inValue)) {}
 		Opcode(Control inValue) : value(static_cast<unsigned>(inValue)) {}
 		Opcode(Object inValue) : value(static_cast<unsigned>(inValue)) {}
 		Opcode(Pattern inValue) : value(static_cast<unsigned>(inValue)) {}
 		Opcode(Literal inValue) : value(static_cast<unsigned>(inValue)) {}
+
+		Opcode(const Opcode& opcode) = default;
+
+		Opcode& operator= (const Opcode& opcode) = default;
+
+		bool operator== (const Opcode& opcode) const
+		{
+			return unsigned{ *this } == unsigned{ opcode };
+		}
+
+		bool operator!= (const Opcode& opcode) const
+		{
+			return !(*this == opcode);
+		}
+		
+		explicit operator unsigned() const
+		{
+			return value;
+		}
+
+		~Opcode() = default;
 
 	private:
 		unsigned value;

--- a/src/chtholly/irgenerator.hpp
+++ b/src/chtholly/irgenerator.hpp
@@ -16,6 +16,7 @@ namespace Chtholly
 		enum class Block : unsigned
 		{
 			Begin = 0x10,
+			NamedBegin,				// 1
 			Drop,
 			End
 		};
@@ -37,7 +38,12 @@ namespace Chtholly
 		};
 		enum class Object : unsigned
 		{
-			Var = 0x50,				// 1
+			Begin = 0x50,
+			End,
+			EndWithInit,
+			AttachTo,				// 1
+			StartPattern,
+			Var,					// 1
 			VarWithConstraint,		// 1
 			VarPack,				// 1
 			VarPackWithConstraint,	// 1
@@ -46,12 +52,6 @@ namespace Chtholly
 			ConstPack,				// 1
 			ConstPackWithConstraint,// 1
 			Use,					// 1
-			Init
-		};
-		enum class Pattern : unsigned
-		{
-			Begin = 0x60,
-			End
 		};
 		enum class Literal : unsigned
 		{
@@ -71,7 +71,6 @@ namespace Chtholly
 		Opcode(List inValue) : value(static_cast<unsigned>(inValue)) {}
 		Opcode(Control inValue) : value(static_cast<unsigned>(inValue)) {}
 		Opcode(Object inValue) : value(static_cast<unsigned>(inValue)) {}
-		Opcode(Pattern inValue) : value(static_cast<unsigned>(inValue)) {}
 		Opcode(Literal inValue) : value(static_cast<unsigned>(inValue)) {}
 
 		Opcode(const Opcode& opcode) = default;

--- a/src/chtholly/irgenerator.hpp
+++ b/src/chtholly/irgenerator.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <vector>
+#include <variant>
+
+#include "parsetree.hpp"
+
+namespace Chtholly
+{
+	struct Opcode
+	{
+		enum : unsigned
+		{
+			None = 0
+		};
+		enum class Block : unsigned
+		{
+			Begin = 0x10,
+			Drop,
+			End
+		};
+		enum class Lambda : unsigned
+		{
+			Begin = 0x20,
+			End
+		};
+		enum class List : unsigned
+		{
+			Push = 0x30,
+			Call
+		};
+		enum class Control : unsigned
+		{
+			Jump = 0x40,
+			JumpIf,
+			Mark
+		};
+		enum class Object : unsigned
+		{
+			Var = 0x50,
+			VarWithInit,
+			VarWithConstraint,
+			VarWithInitAndConstraint,
+			Const,
+			ConstWithInit,
+			ConstWithConstraint,
+			ConstWithInitAndConstraint,
+			Use
+		};
+		enum class Pattern : unsigned
+		{
+			Var = 0x60,
+			VarWithConstraint,
+			Vars,
+			VarsWithConstraint,
+			Const,
+			ConstWithConstraint,
+			Consts,
+			ConstsWithConstraint
+		};
+		enum class Literal : unsigned
+		{
+			Int = 0x70,
+			Float,
+			String,
+			Null,
+			Undef,
+			True,
+			False
+		};
+
+		Opcode() : value(None) {}
+
+		Opcode(Block inValue) : value(static_cast<unsigned>(inValue)) {}
+		Opcode(Lambda inValue) : value(static_cast<unsigned>(inValue)) {}
+		Opcode(List inValue) : value(static_cast<unsigned>(inValue)) {}
+		Opcode(Control inValue) : value(static_cast<unsigned>(inValue)) {}
+		Opcode(Object inValue) : value(static_cast<unsigned>(inValue)) {}
+		Opcode(Pattern inValue) : value(static_cast<unsigned>(inValue)) {}
+		Opcode(Literal inValue) : value(static_cast<unsigned>(inValue)) {}
+
+	private:
+		unsigned value;
+	};
+
+}

--- a/src/chtholly/parser.hpp
+++ b/src/chtholly/parser.hpp
@@ -397,8 +397,8 @@ namespace Chtholly
 				)(info);
 		});
 
-		// ConstraintPartAtConstraintExperssion = ':' PrimaryExpression
-		inline static const Process ConstraintPartAtConstraintExperssion = Process([](Info info) {
+		// ConstraintPartAtConstraintExpression = ':' PrimaryExpression
+		inline static const Process ConstraintPartAtConstraintExpression = Process([](Info info) {
 			return
 				(
 					Term(Match(':')),
@@ -406,8 +406,8 @@ namespace Chtholly
 				)(info);
 		});
 
-		// ConstraintPartAtConstraintExperssionAtPatternExperssion = ':' SingleExpression
-		inline static const Process ConstraintPartAtConstraintExperssionAtPatternExperssion = Process([](Info info) {
+		// ConstraintPartAtConstraintExpressionAtPatternExpression = ':' SingleExpression
+		inline static const Process ConstraintPartAtConstraintExpressionAtPatternExpression = Process([](Info info) {
 			return
 				(
 					Term(Match(':')),
@@ -415,69 +415,69 @@ namespace Chtholly
 				)(info);
 		});
 
-		// ConstraintExperssion = Identifier ConstraintPartAtConstraintExperssion?
-		inline static const Process ConstraintExperssion = Process([](Info info) {
+		// ConstraintExpression = Identifier ConstraintPartAtConstraintExpression?
+		inline static const Process ConstraintExpression = Process([](Info info) {
 			return
 				(
-					ChangeIn("ConstraintExperssion"),
+					ChangeIn("ConstraintExpression"),
 					Term(Identifier),
-					~ConstraintPartAtConstraintExperssion,
+					~ConstraintPartAtConstraintExpression,
 					ChangeOut()
 				)(info);
 		});
 
-		// ConstraintExperssionAtPatternExperssion = Identifier "..."? ConstraintPartAtConstraintExperssionAtPatternExperssion?
-		inline static const Process ConstraintExperssionAtPatternExperssion = Process([](Info info) {
+		// ConstraintExpressionAtPatternExpression = Identifier "..."? ConstraintPartAtConstraintExpressionAtPatternExpression?
+		inline static const Process ConstraintExpressionAtPatternExpression = Process([](Info info) {
 			return
 				(
-					ChangeIn("ConstraintExperssionAtPatternExperssion"),
+					ChangeIn("ConstraintExpressionAtPatternExpression"),
 					(
 						Term(Identifier),
 						~Term(Catch(Match(GL("...")), "Separator"))
 						),
-					~ConstraintPartAtConstraintExperssionAtPatternExperssion,
+					~ConstraintPartAtConstraintExpressionAtPatternExpression,
 					ChangeOut()
 				)(info);
 		});
 
 
-		// PatternExperssion = '(' ( ConstraintExperssionAtPatternExperssion ((','|';') ConstraintExperssionAtPatternExperssion)* (','|';')? | Atom ) ')' ConstraintPartAtConstraintExperssion?
-		inline static const Process PatternExperssion = Process([](Info info) {
+		// PatternExpression = '(' ( ConstraintExpressionAtPatternExpression ((','|';') ConstraintExpressionAtPatternExpression)* (','|';')? | Atom ) ')' ConstraintPartAtConstraintExpression?
+		inline static const Process PatternExpression = Process([](Info info) {
 			return
 				(
 					Term(Match('(')),
-					ChangeIn("PatternExperssion"),
+					ChangeIn("PatternExpression"),
 					(
 						Term(Match(')')) |
 						(
-							MultiExpressionPackage(ConstraintExperssionAtPatternExperssion),
+							MultiExpressionPackage(ConstraintExpressionAtPatternExpression),
 							Term(Match(')')),
-							~ConstraintPartAtConstraintExperssion
+							~ConstraintPartAtConstraintExpression
 							)
 						),
 					ChangeOut()
 				)(info);
 		});
 
-		// VarDefineExpression = "var" (ConstraintExperssion | PatternExperssion) ~List
+		// VarDefineExpression = "var" (ConstraintExpression | PatternExpression) ~List
 		inline static const Process VarDefineExpression = Process([](Info info) {
 			return
 				(
 					Term(MatchKey(GL("var"))),
 					ChangeIn("VarDefineExpression"),
-					PatternExperssion | ConstraintExperssion,
+					PatternExpression | ConstraintExpression,
 					~List,
 					ChangeOut()
 				)(info);
 		});
 		
-		// ConstDefineExpression = "const" (ConstraintExperssion | PatternExperssion) ~List
+		// ConstDefineExpression = "const" (ConstraintExpression | PatternExpression) ~List
 		inline static const Process ConstDefineExpression = Process([](Info info) {
 			return
 				(
 					Term(MatchKey(GL( "const"))),
 					ChangeIn("ConstDefineExpression"),
-					PatternExperssion | ConstraintExperssion,
+					PatternExpression | ConstraintExpression,
 					~List,
 					ChangeOut()
 				)(info);
@@ -493,14 +493,14 @@ namespace Chtholly
 				)(info);
 		});
 
-		// LambdaExperssion = DefineExpression | "fn" PatternExperssion SingleExpression
-		inline static const Process LambdaExperssion = Process([](Info info) {
+		// LambdaExpression = DefineExpression | "fn" PatternExpression SingleExpression
+		inline static const Process LambdaExpression = Process([](Info info) {
 			return
 				(
 					(
 						Term(MatchKey(GL("fn"))),
 						ChangeIn("LambdaExpression"),
-						PatternExperssion,
+						PatternExpression,
 						SingleExpression,
 						ChangeOut()
 					) |
@@ -508,7 +508,7 @@ namespace Chtholly
 				)(info);
 		});
 
-		// ConditionExpression = LambdaExperssion | "if" '(' Expression ')' SingleExpression ("else" SingleExpression)?
+		// ConditionExpression = LambdaExpression | "if" '(' Expression ')' SingleExpression ("else" SingleExpression)?
 		inline static const Process ConditionExpression = Process([](Info info) {
 			return
 				(
@@ -523,7 +523,7 @@ namespace Chtholly
 						),
 						ChangeOut()
 					) |
-					LambdaExperssion
+					LambdaExpression
 				)(info);
 		});
 
@@ -636,18 +636,18 @@ namespace Chtholly
 				)(info);
 		});
 
-		// FoldExperssion = PointExpression "..."*
+		// FoldExpression = PointExpression "..."*
 		inline static const Process FoldExpression = Process([](Info info) {
 			return
 				(
-					ChangeIn("FoldExperssion"),
+					ChangeIn("FoldExpression"),
 					PointExpression,
 					~Term(Catch(Match(GL("...")),"Separator")),
 					ChangeOut(true)
 				)(info);
 		});
 
-		// UnaryExpression = FoldExperssion | (('+' | '-') | "not") UnaryExpression
+		// UnaryExpression = FoldExpression | (('+' | '-') | "not") UnaryExpression
 		inline static const Process UnaryExpression = Process([](Info info) {
 			return
 				(
@@ -737,7 +737,7 @@ namespace Chtholly
 				)(info);
 		});
 
-		// PairExperssion = AssignmentExpression | PairExperssion ':' SingleExpression
+		// PairExpression = AssignmentExpression | PairExpression ':' SingleExpression
 		inline static const Process PairExpression = Process([](Info info) {
 			return
 				(

--- a/src/chtholly/parsetree.hpp
+++ b/src/chtholly/parsetree.hpp
@@ -61,15 +61,15 @@ namespace Chtholly
 
 			template <typename ...T, std::enable_if_t<std::is_constructible_v<ValueType, T&&...>, int> = 0>
 			Node(Iterator in_parent, T&& ...args)
-				: value(std::forward<T>(args)...), parent(in_parent) {}
+				: value(std::forward<T>(args)...), parent(std::move(in_parent)) {}
 
 			template <typename ...T, std::enable_if_t<std::is_constructible_v<ValueType, T&&...>, int> = 0>
-			Node(const Container& in_children, T&& ...args) 
-				: value(std::forward<T>(args)...), children(in_children) {}
+			Node(Container in_children, T&& ...args) 
+				: value(std::forward<T>(args)...), children(std::move(in_children)) {}
 
 			template <typename ...T, std::enable_if_t<std::is_constructible_v<ValueType, T&&...>, int> = 0>
-			Node(Iterator in_parent, const Container& in_children, T&& ...args)
-				: value(std::forward<T>(args)...), parent(in_parent), children(in_children) {}
+			Node(Iterator in_parent, Container in_children, T&& ...args)
+				: value(std::forward<T>(args)...), parent(std::move(in_parent)), children(std::move(in_children)) {}
 
 			Node(const Node& src)
 				: value(src.value), parent(src.parent), children(src.children) {}
@@ -139,7 +139,7 @@ namespace Chtholly
 
 			Iterator nodeIter;
 
-			explicit Observer(const Iterator& src) : nodeIter(src) {}
+			explicit Observer(Iterator src) : nodeIter(std::move(src)) {}
 
 			Observer& operator=(const Iterator& src)
 			{
@@ -249,7 +249,7 @@ namespace Chtholly
 				return nodeIter->children.back().value;
 			}
 
-			~Observer() {}
+			~Observer() = default;
 		};
 
 		class Visitor
@@ -260,7 +260,7 @@ namespace Chtholly
 
 			Iterator nodeIter;
 
-			explicit Visitor(const Iterator& src) : nodeIter(src) {}
+			explicit Visitor(Iterator src) : nodeIter(std::move(src)) {}
 
 			Visitor& operator=(const Iterator& src)
 			{
@@ -378,7 +378,7 @@ namespace Chtholly
 				return nodeIter->children.back().value;
 			}
 
-			~Visitor() {}
+			~Visitor() = default;
 		};
 
 		class Modifier : public Visitor
@@ -595,7 +595,7 @@ namespace Chtholly
 				return newModi;
 			}
 
-			~Modifier() {}
+			~Modifier() = default;
 		};
 
 		template <typename ...T, std::enable_if_t<std::is_constructible_v<Node, T&&...>, int> = 0>
@@ -678,7 +678,7 @@ namespace Chtholly
 			FixParent(modifier());
 		}
 
-		~BasicTree() {}
+		~BasicTree() = default;
 	};
 
 	template <typename inStringView>
@@ -700,7 +700,7 @@ namespace Chtholly
 		StringView value;
 
 		template <typename ...T, std::enable_if_t<std::is_constructible_v<StringView, T&&...>, int> = 0>
-		BasicParseUnit(Type inType, const String& inName, T&& ... inValue) : type(inType), name(inName), value(inValue...) {}
+		BasicParseUnit(Type inType, String inName, T&& ... inValue) : type(inType), name(std::move(inName)), value(inValue...) {}
 
 		BasicParseUnit(const BasicParseUnit& src) : type(src.type), name(src.name), value(src.value) {}
 
@@ -722,7 +722,7 @@ namespace Chtholly
 			return !(*this == other);
 		}
 
-		~BasicParseUnit() {}
+		~BasicParseUnit() = default;
 	};
 
 	template<typename ValueType>

--- a/test/parser-test.cpp
+++ b/test/parser-test.cpp
@@ -97,14 +97,14 @@ TEST(Expression, DefineExpression)
 {
 	EXPECT_EQ(parseString("var x"), ParseTree(
 		Term("VarDefineExpression", 
-			Term("ConstraintExperssion",
+			Term("ConstraintExpression",
 				Token("Identifier", "x")
 			)
 		)
 	));
 	EXPECT_EQ(parseString("const hello(0)"), ParseTree(
 		Term("ConstDefineExpression", 
-			Term("ConstraintExperssion",
+			Term("ConstraintExpression",
 				Token("Identifier", "hello")
 			),
 			Token("IntLiteral", "0")
@@ -112,7 +112,7 @@ TEST(Expression, DefineExpression)
 	));
 	EXPECT_EQ(parseString("var y: int"), ParseTree(
 		Term("VarDefineExpression", 
-			Term("ConstraintExperssion",
+			Term("ConstraintExpression",
 				Token("Identifier", "y"), 
 				Token("Identifier", "int")
 			)
@@ -120,12 +120,12 @@ TEST(Expression, DefineExpression)
 	));
 	EXPECT_EQ(parseString("var (x...,y:int,z):numbers(1.0;2.0;3;4;5.0)"), ParseTree(
 		Term("VarDefineExpression",
-			Term("PatternExperssion",
-				Term("ConstraintExperssionAtPatternExperssion",Token("Identifier","x"), Token("Separator", "...")),
+			Term("PatternExpression",
+				Term("ConstraintExpressionAtPatternExpression",Token("Identifier","x"), Token("Separator", "...")),
 				Token("Separator", ","),
-				Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "y"), Token("Identifier", "int")),
+				Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "y"), Token("Identifier", "int")),
 				Token("Separator", ","),
-				Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "z")),
+				Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "z")),
 				Token("Identifier", "numbers")
 			),
 			Term("Expression",
@@ -147,8 +147,8 @@ TEST(Expression, LambdaExpression)
 {
 	EXPECT_EQ(parseString("fn(x) x"), ParseTree(
 		Term("LambdaExpression",
-			Term("PatternExperssion",
-				Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "x"))
+			Term("PatternExpression",
+				Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "x"))
 			),
 			Token("Identifier", "x")
 		)
@@ -156,10 +156,10 @@ TEST(Expression, LambdaExpression)
 
 	EXPECT_EQ(parseString("fn(x,y) if(x>y) x else y"), ParseTree(
 		Term("LambdaExpression",
-			Term("PatternExperssion",
-				Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "x")),
+			Term("PatternExpression",
+				Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "x")),
 				Token("Separator", ","),
-				Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "y"))
+				Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "y"))
 			),
 			Term("ConditionExpression",
 				Term("RelationalExpression",
@@ -175,12 +175,12 @@ TEST(Expression, LambdaExpression)
 
 	EXPECT_EQ(parseString("fn(x,y,z):number x*x+y*y+z*z"), ParseTree(
 		Term("LambdaExpression",
-			Term("PatternExperssion",
-				Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "x")),
+			Term("PatternExpression",
+				Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "x")),
 				Token("Separator", ","),
-				Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "y")),
+				Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "y")),
 				Token("Separator", ","),
-				Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "z")),
+				Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "z")),
 				Token("Identifier", "number")
 			),
 			Term("AdditiveExpression",
@@ -207,15 +207,15 @@ TEST(Expression, LambdaExpression)
 
 	EXPECT_EQ(parseString("fn(x,y) (var temp=x, x=y; y=temp)"), ParseTree(
 		Term("LambdaExpression",
-			Term("PatternExperssion",
-				Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "x")),
+			Term("PatternExpression",
+				Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "x")),
 				Token("Separator", ","),
-				Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "y"))
+				Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "y"))
 			),
 			Term("Expression",
 				Term("AssignmentExpression",
 					Term("VarDefineExpression",
-						Term("ConstraintExperssion",
+						Term("ConstraintExpression",
 							Token("Identifier", "temp")
 						)
 					),
@@ -356,7 +356,7 @@ TEST(Expression, WhileLoopExpression)
 	EXPECT_EQ(parseString("var i(0),var sum(0) += while(i<10) i+=1"), ParseTree(
 		Term("Expression",
 			Term("VarDefineExpression",
-				Term("ConstraintExperssion",
+				Term("ConstraintExpression",
 					Token("Identifier", "i")
 				),
 				Token("IntLiteral", "0")
@@ -364,7 +364,7 @@ TEST(Expression, WhileLoopExpression)
 			Token("Separator", ","),
 			Term("AssignmentExpression",
 				Term("VarDefineExpression",
-					Term("ConstraintExperssion",
+					Term("ConstraintExpression",
 						Token("Identifier", "sum")
 					),
 					Token("IntLiteral", "0")
@@ -389,7 +389,7 @@ TEST(Expression, WhileLoopExpression)
 	EXPECT_EQ(parseString("var i(0),while(len(array) > i and array->i <> 233) (i+=1,) else i"), ParseTree(
 		Term("Expression",
 			Term("VarDefineExpression",
-				Term("ConstraintExperssion",
+				Term("ConstraintExpression",
 					Token("Identifier", "i")
 				),
 				Token("IntLiteral", "0")
@@ -496,10 +496,10 @@ TEST(Expression, FunctionExpression)
 		Term("FunctionExpression",
 			Token("Identifier", "sort"),
 			Term("LambdaExpression",
-				Term("PatternExperssion",
-					Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "x")),
+				Term("PatternExpression",
+					Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "x")),
 					Token("Separator", ","),
-					Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "y"))
+					Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "y"))
 				),
 				Term("RelationalExpression",
 					Token("Identifier", "x"),
@@ -577,14 +577,14 @@ TEST(Expression, PointExpression)
 TEST(Expression, FoldExpression)
 {
 	EXPECT_EQ(parseString("args..."), ParseTree(
-		Term("FoldExperssion",
+		Term("FoldExpression",
 			Token("Identifier", "args"),
 			Token("Separator","...")
 		)
 	));
 
 	EXPECT_EQ(parseString("(args + 1)..."), ParseTree(
-		Term("FoldExperssion",
+		Term("FoldExpression",
 			Term("AdditiveExpression",
 				Token("Identifier", "args"),
 				Token("BinaryOperator", "+"),
@@ -596,14 +596,14 @@ TEST(Expression, FoldExpression)
 
 	EXPECT_EQ(parseString("fn(f,x...) f(x...)"), ParseTree(
 		Term("LambdaExpression",
-			Term("PatternExperssion",
-				Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "f")),
+			Term("PatternExpression",
+				Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "f")),
 				Token("Separator", ","),
-				Term("ConstraintExperssionAtPatternExperssion", Token("Identifier", "x"), Token("Separator", "..."))
+				Term("ConstraintExpressionAtPatternExpression", Token("Identifier", "x"), Token("Separator", "..."))
 			),
 			Term("FunctionExpression",
 				Token("Identifier", "f"),
-				Term("FoldExperssion",
+				Term("FoldExpression",
 					Token("Identifier", "x"),
 					Token("Separator", "...")
 				)
@@ -1071,7 +1071,7 @@ TEST(Expression, ExpressionList)
 			Token("Separator", ","),
 			Term("AssignmentExpression",
 				Term("VarDefineExpression",
-					Term("ConstraintExperssion",
+					Term("ConstraintExpression",
 						Token("Identifier", "c")
 					)
 				),
@@ -1124,7 +1124,7 @@ TEST(Expression, ArrayList)
 				Term("RelationalExpression",
 					Term("AssignmentExpression",
 						Term("VarDefineExpression",
-							Term("ConstraintExperssion",
+							Term("ConstraintExpression",
 								Token("Identifier", "i")
 							),
 							Token("IntLiteral", "0")
@@ -1169,7 +1169,7 @@ TEST(Expression, DictList)
 				Term("RelationalExpression",
 					Term("AssignmentExpression",
 						Term("VarDefineExpression",
-							Term("ConstraintExperssion",
+							Term("ConstraintExpression",
 								Token("Identifier", "i")
 							),
 							Token("IntLiteral", "0")


### PR DESCRIPTION
- MSVC sln: add user dictionary for typo fixing
- CharType: replace all of `Type` with `auto`  & add static_cast to std::is*
- fix typo: in BasicParser & its Unit testing
- ParseTree: using default c/dtor & using std::move for params
- [WIP & Deprecated] IRGenerator